### PR TITLE
added permission so copy button works

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -30,6 +30,6 @@
   "options_ui": { 
 	"page": "html/options.html"
   },
-  "permissions": ["activeTab", "storage", "alarms"],
+  "permissions": ["activeTab", "storage", "alarms", "clipboardWrite"],
   "version": "0.8.5.1"
 }


### PR DESCRIPTION
This enables the copy button to work as expected in Firefox. 